### PR TITLE
the unit of decay is Seconds,not Minutes.

### DIFF
--- a/src/Http/Middleware/ThrottleRequests.php
+++ b/src/Http/Middleware/ThrottleRequests.php
@@ -31,19 +31,19 @@ class ThrottleRequests
 	 * @param \Illuminate\Http\Request $request
 	 * @param \Closure                 $next
 	 * @param int                      $maxAttempts
-	 * @param int                      $decayMinutes
+	 * @param int                      $decaySeconds
 	 *
 	 * @return mixed
 	 */
-	public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
+	public function handle($request, Closure $next, $maxAttempts = 60, $decaySeconds = 1)
 	{
 		$key = $this->resolveRequestSignature($request);
 
-		if ($this->limiter->tooManyAttempts($key, $maxAttempts, $decayMinutes)) {
+		if ($this->limiter->tooManyAttempts($key, $maxAttempts, $decaySeconds)) {
 			return $this->buildResponse($key, $maxAttempts);
 		}
 
-		$this->limiter->hit($key, $decayMinutes);
+		$this->limiter->hit($key, $decaySeconds);
 
 		$response = $next($request);
 


### PR DESCRIPTION
the unit of decay is Seconds,not Minutes.
延时单位应该是秒，不是分。